### PR TITLE
Feature/logout all device

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -13,6 +13,7 @@ This endpoint is used for user login. It accepts user credentials and returns a 
 #### Request
 
 - **URL:** `/api/v1/auth/login`
+- **ROLE** `PERMIT ALL`
 - **Method:** `POST`
 - **Content-Type:** `application/json`
 - **Request Body:**
@@ -48,6 +49,7 @@ This endpoint allows users or admins to refresh their expired access token. It r
 #### Request
 
 - **URL:** `/api/v1/auth/refresh`
+- **ROLE** `PERMIT ALL`
 - **Method:** `POST`
 - **Content-Type:** `application/json`
 - **Request Cookie:**
@@ -77,11 +79,12 @@ This endpoint allows users or admins to refresh their expired access token. It r
 
 ### POST /api/v1/auth/logout
 
-This endpoint allows users or admins to log out of their account. It requires a valid refresh token from HTTP-only cookies and is only valid for use at the path /api/v1/auth/. This endpoint only deletes and revokes the refresh token associated with the user's cookie, which was set during the user's initial login. If the same user logs in from a different device, they will still be able to authenticate to the web app.
+This endpoint allows users or admins to log out of their account. It requires a valid refresh token from HTTP-only cookies and is only valid for use at the path `/api/v1/auth/`. This endpoint only deletes and revokes the refresh token associated with the user's cookie, which was set during the user's initial login. If the same user logs in from a different device, they will still be able to authenticate to the web app.
 
 #### Request
 
 - **URL:** `/api/v1/auth/logout`
+- **ROLE** `USER`, `ADMIN`
 - **Method:** `POST`
 - **Content-Type:** `application/json`
 - **Request Cookie:**
@@ -106,3 +109,57 @@ This endpoint allows users or admins to log out of their account. It requires a 
     ```Text
     Set-Cookie = refresh_token=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:10 GMT; Path=/api/v1/auth/; HttpOnly
     ```
+
+### POST /api/v1/auth/revoke
+
+This endpoint allows users to log out of all their active sessions across all devices. This is useful for scenarios where a user wants to ensure their account is secure by ending all other active sessions.
+
+#### Request
+
+- **URL:** `/api/v1/auth/revoke`
+- **ROLE** `USER`
+- **Method:** `POST`
+- **Content-Type:** `application/json`
+- **Request Cookie:**
+  ```text
+  Cookie refresh_token={your_refresh_token}
+  ```
+
+#### Response
+- **Status Code: `200 OK`**
+- **Content-Type:** `application/json`
+- **Response Body:**
+  ```json
+  {
+    "code": 200,
+    "message": "OK",
+    "data": null,
+    "errors": null
+  }
+
+### POST /api/v1/auth/revoke/{userId}
+
+This endpoint allows an admin to log out a specific user from all their active sessions across all devices. Instead of deleting the refresh tokens, this endpoint marks them as blacklisted. This is useful for ensuring the security of a user's account by ending all active sessions or if an admin needs to enforce a global logout for a specific user.
+
+#### Request
+
+- **URL:** `/api/v1/auth/revoke/{userId}`
+- **ROLE** `ADMIN`
+- **Method:** `POST`
+- **Content-Type:** `application/json`
+- **Request Path Parameter:**
+  ```text
+  userId = 15
+  ```
+
+#### Response
+- **Status Code: `200 OK`**
+- **Content-Type:** `application/json`
+- **Response Body:**
+  ```json
+  {
+    "code": 200,
+    "message": "OK",
+    "data": null,
+    "errors": null
+  }

--- a/src/main/java/com/taskmaster/taskmaster/controller/AuthController.java
+++ b/src/main/java/com/taskmaster/taskmaster/controller/AuthController.java
@@ -10,11 +10,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
@@ -77,6 +73,34 @@ public class AuthController {
         HttpServletResponse httpServletResponse
     ) {
         authService.logout(refreshToken, httpServletResponse);
+
+        return WebResponse.<String>builder()
+            .code(HttpStatus.OK.value())
+            .message(HttpStatus.OK.getReasonPhrase())
+            .build();
+    }
+
+    @PostMapping(
+        path = "/revoke"
+    )
+    public WebResponse<String> revokeUserInAllDevice(
+        @CookieValue("refresh_token") String refreshToken
+    ) {
+        authService.revokeUserInAllDevice(refreshToken);
+
+        return WebResponse.<String>builder()
+            .code(HttpStatus.OK.value())
+            .message(HttpStatus.OK.getReasonPhrase())
+            .build();
+    }
+
+    @PostMapping(
+        path = "/revoke/{userId}"
+    )
+    public WebResponse<String> revokeUserInAllDeviceForAdmin(
+        @PathVariable(name = "userId") Long userId
+    ) {
+        authService.revokeUserInAllDeviceForAdmin(userId);
 
         return WebResponse.<String>builder()
             .code(HttpStatus.OK.value())

--- a/src/main/java/com/taskmaster/taskmaster/entity/RefreshToken.java
+++ b/src/main/java/com/taskmaster/taskmaster/entity/RefreshToken.java
@@ -43,6 +43,9 @@ public class RefreshToken {
     @Column(name = "issued_at", nullable = false)
     private LocalDateTime issuedAt;
 
+    @Column(name = "blacklist")
+    private boolean isBlacklist;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;

--- a/src/main/java/com/taskmaster/taskmaster/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/taskmaster/taskmaster/repository/RefreshTokenRepository.java
@@ -1,11 +1,11 @@
 package com.taskmaster.taskmaster.repository;
 
 import com.taskmaster.taskmaster.entity.RefreshToken;
-import com.taskmaster.taskmaster.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -13,10 +13,15 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
     Optional<RefreshToken> findByToken(String token);
 
-    void deleteByUserAndExpiredAtBefore(User user, LocalDateTime now);
-
-    void deleteByToken(String token);
-
     boolean existsByToken(String refreshToken);
+
+    Optional<RefreshToken> findByTokenAndIsBlacklistFalse(String token);
+
+    List<RefreshToken> findByExpiredAtBeforeAndIsBlacklistTrue(LocalDateTime now);
+
+    List<RefreshToken> findByUser_Id(Long userId);
+
+    List<RefreshToken> findByUser_Username(String currentUser);
+
 
 }

--- a/src/main/java/com/taskmaster/taskmaster/repository/UserRepository.java
+++ b/src/main/java/com/taskmaster/taskmaster/repository/UserRepository.java
@@ -2,8 +2,6 @@ package com.taskmaster.taskmaster.repository;
 
 import com.taskmaster.taskmaster.entity.Study;
 import com.taskmaster.taskmaster.entity.User;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -20,15 +18,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUsername(String username);
 
-    Page<User> findByUsername(String username, Pageable pageable);
-
     boolean existsByEmail(String email);
 
     Optional<User> findByEmail(String email);
 
     boolean existsByUsernameAndStudies(String username, Study study);
-
-    boolean existsByUsername(String username);
 
     boolean existsByPhone(String phone);
 

--- a/src/main/java/com/taskmaster/taskmaster/security/SecurityConfiguration.java
+++ b/src/main/java/com/taskmaster/taskmaster/security/SecurityConfiguration.java
@@ -47,6 +47,8 @@ public class SecurityConfiguration {
                 .antMatchers(HttpMethod.GET,"/api/v1/studies/{studyId}").permitAll()
                 .antMatchers(HttpMethod.POST,"/api/v1/auth/refresh").permitAll()
                 .antMatchers(HttpMethod.POST,"/api/v1/auth/logout").hasAnyRole(UserRole.USER.name(), UserRole.ADMIN.name())
+                .antMatchers(HttpMethod.POST,"/api/v1/auth/revoke").hasAnyRole(UserRole.USER.name())
+                .antMatchers(HttpMethod.POST,"/api/v1/auth/revoke/{userId}").hasAnyRole(UserRole.ADMIN.name())
                 .antMatchers(HttpMethod.POST,"/api/v1/studies").hasRole(UserRole.ADMIN.name())
                 .antMatchers(HttpMethod.GET,"/api/v1/studies/me").hasRole(UserRole.USER.name())
                 .antMatchers(HttpMethod.DELETE,"/api/v1/studies/{studyId}").hasRole(UserRole.ADMIN.name())

--- a/src/main/java/com/taskmaster/taskmaster/service/AuthService.java
+++ b/src/main/java/com/taskmaster/taskmaster/service/AuthService.java
@@ -20,4 +20,8 @@ public interface AuthService {
 
     String createRefreshToken(String username);
 
+    void revokeUserInAllDevice(String refreshToken);
+
+    void revokeUserInAllDeviceForAdmin(Long userId);
+
 }

--- a/src/main/java/com/taskmaster/taskmaster/service/JwtService.java
+++ b/src/main/java/com/taskmaster/taskmaster/service/JwtService.java
@@ -64,11 +64,9 @@ public class JwtService {
             .compact();
     }
 
-    public boolean isRefreshTokenValid(String token) {
-        RefreshToken storedRefreshToken = refreshTokenRepository.findByToken(token)
-            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Refresh token not found!"));
-
-        refreshTokenRepository.deleteByUserAndExpiredAtBefore(storedRefreshToken.getUser(),LocalDateTime.now());
+    public boolean isRefreshTokenValid(RefreshToken refreshToken) {
+        RefreshToken storedRefreshToken = refreshTokenRepository.findByTokenAndIsBlacklistFalse(refreshToken.getToken())
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Refresh token not found or is blacklisted!"));
 
         return !storedRefreshToken.getExpiredAt().isBefore(LocalDateTime.now());
     }


### PR DESCRIPTION
Implement new API endpoint for logout all device account for **USER** and **ADMIN** roles

- Instead of deleting refresh token in database, i prefer to mark the refresh token to blacklisted
- Path : ADMIN - POST /api/v1/auth/revoke/{userId}
- Path : USER - POST /api/v1/auth/revoke